### PR TITLE
Force read into memory

### DIFF
--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -143,9 +143,9 @@ tar_rast_read <- function(preserve_metadata) {
         zip = function(path) {
             tmp <- withr::local_tempdir()
             zip::unzip(zipfile = path, exdir = tmp)
-            terra::rast(file.path(tmp, basename(path)))
+            terra::rast(file.path(tmp, basename(path))) + 0
         },
-        drop = function(path) terra::rast(path)
+        drop = function(path) terra::rast(path) + 0
     )
 }
 

--- a/R/tar-terra-rast.R
+++ b/R/tar-terra-rast.R
@@ -29,6 +29,12 @@
 #'   are retained by archiving all written files as a zip file upon writing and
 #'   unzipping them upon reading. This adds extra overhead and will slow
 #'   pipelines.
+#' @param force_memory logical. When `TRUE`, `SpatRaster` targets are guaranteed
+#'   to point to an in-memory source when loaded with `tar_read()` or
+#'   `tar_load()`. This may be necessary if using cloud storage with `targets`
+#'   since files are only downloaded temporarily when targets are loaded.
+#'   Defaults to `FALSE` which allows `SpatRaster` targets to point to files in
+#'   a local object store.
 #' @param ... Additional arguments not yet used
 #'
 #' @inheritParams targets::tar_target
@@ -62,6 +68,7 @@ tar_terra_rast <- function(name,
                            filetype = geotargets_option_get("gdal.raster.driver"),
                            gdal = geotargets_option_get("gdal.raster.creation.options"),
                            preserve_metadata = geotargets_option_get("terra.preserve.metadata"),
+                           force_memory = FALSE,
                            ...,
                            tidy_eval = targets::tar_option_get("tidy_eval"),
                            packages = targets::tar_option_get("packages"),
@@ -116,8 +123,15 @@ tar_terra_rast <- function(name,
         packages = packages,
         library = library,
         format = targets::tar_format(
-            read = tar_rast_read(preserve_metadata = preserve_metadata),
-            write = tar_rast_write(filetype = filetype, gdal = gdal, preserve_metadata = preserve_metadata),
+            read = tar_rast_read(
+                preserve_metadata = preserve_metadata,
+                force_memory = force_memory
+            ),
+            write = tar_rast_write(
+                filetype = filetype,
+                gdal = gdal,
+                preserve_metadata = preserve_metadata
+            ),
             marshal = function(object) terra::wrap(object),
             unmarshal = function(object) terra::unwrap(object),
             substitute = list(filetype = filetype, gdal = gdal, preserve_metadata = preserve_metadata)
@@ -137,7 +151,7 @@ tar_terra_rast <- function(name,
     )
 }
 
-tar_rast_read <- function(preserve_metadata) {
+tar_rast_read <- function(preserve_metadata, force_memory) {
     switch(
         preserve_metadata,
         zip = function(path) {


### PR DESCRIPTION
This is a necessary addition to `tar_terra_rast()` for `SpatRaster` targets to work with cloud storage. (see more discussion in https://github.com/ropensci/targets/discussions/1367).  I added a parameter and some documentation, but haven't figured out how to "hook it up" efficiently.  When `force_memory` is true, it needs to modify the body of the read function to add ` + 0` or `* 1` to the end.  Tried messing around with `body(fun)` and `rlang::expr()` but didn't get anything satisfactory.  I'm open to ideas and alternatives! 

One alternative is to use the new content addressable storage tools in `targets` to have a custom download function that doesn't actually download the target, but rather returns a `/vsis3/` filepath to the read function.  This is not something we'd implement in `geotargets`, but would be something cool to document in a vignette.  I may play around with this in the next few weeks.