### PR TITLE
tar_stars: skip test with ncdf=TRUE when ncmeta is not installed

### DIFF
--- a/tests/testthat/test-tar-stars.R
+++ b/tests/testthat/test-tar-stars.R
@@ -69,6 +69,7 @@ targets::tar_test("tar_stars(mdim=TRUE) works", {
 
 
 targets::tar_test("tar_stars(mdim=TRUE, ncdf=TRUE) works", {
+  skip_if_not_installed("ncmeta")
   targets::tar_script({
     list(geotargets::tar_stars(test_stars_mdim_ncdf,
       {


### PR DESCRIPTION
This skips the `tar_stars()` tests that require use of `ncmeta` to write netCDF files when `ncmeta` is not installed.