### PR TITLE
Change default driver for SpatVectors to GPKG

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `tar_terra_rast()` gains a `datatype` argument and `tar_stars()` gains a `type` argument. Both default to the geotargets option `"gdal.raster.data.type"` (when set).
 * Additional arguments `...` are now passed to the target "write" method: `terra::writeRaster()` for `tar_terra_rast()`, `terra::writeVector()` for `tar_terra_vect()` and `stars::write_stars()` for `tar_stars()` (Thanks to @brownag in #137, resolves #132 and #127)
 * Added `tar_terra_vrt()` for `SpatRaster` object targets that reference multiple data sources (e.g. tiles created with `tar_terra_tiles()`) using a GDAL Virtual Dataset (VRT) XML file (Thanks to @brownag in #138)
+* The default driver for `tar_terra_vect()` has been changed to `"GPKG"` in order to preserve CRS information (#166).
 
 # geotargets 0.2.0 (29 November 2024)
 

--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -18,14 +18,14 @@
 #'   `"UInt32"`, `"UInt64"`, `"Int16"`, `"Int32"`, `"Int64"`, `"Float32"`,
 #'   `"Float64"` (for stars).
 #' @param gdal_vector_driver character, length 1; set the file type used for
-#' vector data in target store (default: `"GeoJSON"`).
+#' vector data in target store (default: `"GPKG"`).
 #' @param gdal_vector_creation_options character; set the GDAL layer creation
 #'   options used when writing vector files to target store (default:
 #'   `"ENCODING=UTF-8"`). You may specify multiple values e.g.
 #'   `c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")`. Each GDAL driver supports
-#'   a unique set of creation options. For example, with the default `"GeoJSON"`
+#'   a unique set of creation options. For example, with the default `"GPKG"`
 #'   driver:
-#'   <https://gdal.org/drivers/vector/geojson.html#layer-creation-options>
+#'   <https://gdal.org/drivers/vector/gpkg.html#layer-creation-options>
 #' @param terra_preserve_metadata character. When `"drop"` (default), any
 #'   auxiliary files that would be written by [terra::writeRaster()] containing
 #'   raster metadata such as units and datetimes are lost (note that this does

--- a/R/tar-terra-vect.R
+++ b/R/tar-terra-vect.R
@@ -24,8 +24,8 @@
 #'
 #' @note Although you may pass any supported GDAL vector driver to the
 #'   `filetype` argument, not all formats are guaranteed to work with
-#'   `geotargets`.  At the moment, we have tested `GeoJSON` and `ESRI Shapefile`
-#'   which both appear to work generally.
+#'   `geotargets`.  At the moment, we have tested `GPKG`, `GeoJSON` and
+#'   `ESRI Shapefile` which all appear to work generally.
 #' @export
 #' @examples
 #' # For CRAN. Ensures these examples run under certain conditions.
@@ -74,7 +74,7 @@ tar_terra_vect <- function(
   cue = targets::tar_option_get("cue"),
   description = targets::tar_option_get("description")
 ) {
-  filetype <- filetype %||% "GeoJSON"
+  filetype <- filetype %||% "GPKG"
   gdal <- gdal %||% "ENCODING=UTF-8"
 
   # Check that filetype is available

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -35,15 +35,15 @@ One of: \code{"INT1U"}, \code{"INT2U"}, \code{"INT4U"}, \code{"INT8U"}, \code{"I
 \code{"Float64"} (for stars).}
 
 \item{gdal_vector_driver}{character, length 1; set the file type used for
-vector data in target store (default: \code{"GeoJSON"}).}
+vector data in target store (default: \code{"GPKG"}).}
 
 \item{gdal_vector_creation_options}{character; set the GDAL layer creation
 options used when writing vector files to target store (default:
 \code{"ENCODING=UTF-8"}). You may specify multiple values e.g.
 \code{c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")}. Each GDAL driver supports
-a unique set of creation options. For example, with the default \code{"GeoJSON"}
+a unique set of creation options. For example, with the default \code{"GPKG"}
 driver:
-\url{https://gdal.org/drivers/vector/geojson.html#layer-creation-options}}
+\url{https://gdal.org/drivers/vector/gpkg.html#layer-creation-options}}
 
 \item{terra_preserve_metadata}{character. When \code{"drop"} (default), any
 auxiliary files that would be written by \code{\link[terra:writeRaster]{terra::writeRaster()}} containing

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -235,8 +235,8 @@ The \code{iteration} argument is unavailable because it is hard-coded to
 
 Although you may pass any supported GDAL vector driver to the
 \code{filetype} argument, not all formats are guaranteed to work with
-\code{geotargets}.  At the moment, we have tested \code{GeoJSON} and \verb{ESRI Shapefile}
-which both appear to work generally.
+\code{geotargets}.  At the moment, we have tested \code{GPKG}, \code{GeoJSON} and
+\verb{ESRI Shapefile} which all appear to work generally.
 }
 \examples{
 # For CRAN. Ensures these examples run under certain conditions.


### PR DESCRIPTION
Closes #166 by switching default driver to GPKG for `tar_terra_vect()`