### PR TITLE
README typos `tar_tera_tiles`>`tar_terra_tiles`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -75,7 +75,7 @@ We currently provide support for the `terra` package with `targets`. Below we sh
 - `tar_terra_vect()`
 - `tar_terra_sprc()`
 - `tar_terra_sds()`
-- `tar_tera_tiles()`
+- `tar_terra_tiles()`
 - `tar_stars()`
 
 You would use these in place of `tar_target()` in your targets pipeline, e.g., when you are doing work with `terra` raster, vector, or raster collection data.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Below we show three examples of target factories:
 - `tar_terra_vect()`
 - `tar_terra_sprc()`
 - `tar_terra_sds()`
-- `tar_tera_tiles()`
+- `tar_terra_tiles()`
 - `tar_stars()`
 
 You would use these in place of `tar_target()` in your targets pipeline,


### PR DESCRIPTION
No rush---typo is obvious!---but could momentarily mislead the casual copy-paster.