### PR TITLE
Doc updates

### DIFF
--- a/R/geotargets-option.R
+++ b/R/geotargets-option.R
@@ -5,13 +5,13 @@
 #'
 #' @param gdal_raster_driver character, length 1; set the driver used for raster
 #'   data in target store (default: `"GTiff"`). Options for driver names can be
-#'   found here: <https://gdal.org/drivers/raster/index.html>.
+#'   found here: <https://gdal.org/en/stable/drivers/raster/index.html>.
 #' @param gdal_raster_creation_options character; set the GDAL creation options
 #'   used when writing raster files to target store (default: `""`). You may
 #'   specify multiple values e.g. `c("COMPRESS=DEFLATE", "TFW=YES")`. Each GDAL
 #'   driver supports a unique set of creation options. For example, with the
 #'   default `"GTiff"` driver:
-#'   <https://gdal.org/drivers/raster/gtiff.html#creation-options>.
+#'   <https://gdal.org/en/stable/drivers/raster/gtiff.html#creation-options>.
 #' @param gdal_raster_data_type character; Data type for writing raster file.
 #'   One of: `"INT1U"`, `"INT2U"`, `"INT4U"`, `"INT8U"`, `"INT2S"`, `"INT4S"`,
 #'   `"INT8S"`, `"FLT4S"`, `"FLT8S"` (for terra), or `"Byte"`, `"UInt16"`,
@@ -25,7 +25,7 @@
 #'   `c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")`. Each GDAL driver supports
 #'   a unique set of creation options. For example, with the default `"GPKG"`
 #'   driver:
-#'   <https://gdal.org/drivers/vector/gpkg.html#layer-creation-options>
+#'   <https://gdal.org/en/stable/drivers/vector/gpkg.html#layer-creation-options>
 #' @param terra_preserve_metadata character. When `"drop"` (default), any
 #'   auxiliary files that would be written by [terra::writeRaster()] containing
 #'   raster metadata such as units and datetimes are lost (note that this does

--- a/R/tar-stars.R
+++ b/R/tar-stars.R
@@ -25,7 +25,7 @@
 #'  will be read as an object of class `stars_proxy`. Otherwise, the object is
 #'  class `stars`.
 #' @param mdim logical. Use the [Multidimensional Raster Data
-#'  Model](https://gdal.org/user/multidim_raster_data_model.html) via
+#'  Model](https://gdal.org/en/stable/user/multidim_raster_data_model.html) via
 #'  [stars::write_mdim()]? Default: `FALSE`. Only supported for some drivers,
 #'  e.g. `"netCDF"` or `"Zarr"`.
 #' @param ncdf logical. Use the NetCDF library directly to read data via

--- a/R/tar-terra-vrt.R
+++ b/R/tar-terra-vrt.R
@@ -19,6 +19,7 @@
 #' @importFrom rlang %||% arg_match0
 #' @seealso [tar_terra_tiles()]
 #' @export
+#' @return target class "tar_stem" for use in a target pipeline
 #' @examples
 #' if (Sys.getenv("TAR_LONG_EXAMPLES") == "true") {
 #'  targets::tar_dir({ # tar_dir() runs code from a temporary directory.

--- a/man/geotargets-options.Rd
+++ b/man/geotargets-options.Rd
@@ -26,7 +26,7 @@ used when writing raster files to target store (default: \code{""}). You may
 specify multiple values e.g. \code{c("COMPRESS=DEFLATE", "TFW=YES")}. Each GDAL
 driver supports a unique set of creation options. For example, with the
 default \code{"GTiff"} driver:
-\url{https://gdal.org/en/stable/drivers/raster/gtiff.html}.}
+\url{https://gdal.org/en/stable/drivers/raster/gtiff.html#creation-options}.}
 
 \item{gdal_raster_data_type}{character; Data type for writing raster file.
 One of: \code{"INT1U"}, \code{"INT2U"}, \code{"INT4U"}, \code{"INT8U"}, \code{"INT2S"}, \code{"INT4S"},
@@ -43,7 +43,7 @@ options used when writing vector files to target store (default:
 \code{c("WRITE_BBOX=YES", "COORDINATE_PRECISION=10")}. Each GDAL driver supports
 a unique set of creation options. For example, with the default \code{"GPKG"}
 driver:
-\url{https://gdal.org/en/stable/drivers/vector/gpkg.html}}
+\url{https://gdal.org/en/stable/drivers/vector/gpkg.html#layer-creation-options}}
 
 \item{terra_preserve_metadata}{character. When \code{"drop"} (default), any
 auxiliary files that would be written by \code{\link[terra:writeRaster]{terra::writeRaster()}} containing

--- a/man/tar_terra_vrt.Rd
+++ b/man/tar_terra_vrt.Rd
@@ -252,6 +252,9 @@ functions like \code{\link[targets:tar_make]{tar_make()}}. For example,
 lists all the targets whose descriptions start with the character
 string \code{"survival model"}.}
 }
+\value{
+target class "tar_stem" for use in a target pipeline
+}
 \description{
 Provides a target format for \link[terra:SpatRaster-class]{terra::SpatRaster},
 \link[terra:SpatRaster-class]{terra::SpatRasterDataset}, and \link[terra:SpatRaster-class]{terra::SpatRasterCollection}


### PR DESCRIPTION
 - add missing return value for `tar_terra_vrt()`
 - fix GDAL URLs that redirect in the source files. Some look like they are updated in .Rd, also fixed one in `tar_stars()`