### PR TITLE
Fix test "metadata is maintained (gdalraster SOZip)" for GDAL < 3.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     stars,
     testthat (>= 3.0.0),
     fs,
-    gdalraster,
+    gdalraster (>= 2.0.0),
     spelling
 Config/testthat/edition: 3
 URL: https://github.com/ropensci/geotargets, https://docs.ropensci.org/geotargets/

--- a/tests/testthat/test-tar-terra-rast.R
+++ b/tests/testthat/test-tar-terra-rast.R
@@ -201,6 +201,10 @@ tar_test("metadata is maintained for COG", {
 
 tar_test("metadata is maintained (gdalraster SOZip)", {
   skip_if_not_installed("gdalraster")
+  skip_if(
+    gdalraster::gdal_version_num() < gdalraster::gdal_compute_version(3, 7, 0)
+  )
+
   tar_script({
     library(targets)
     library(geotargets)


### PR DESCRIPTION
This PR skips the test that uses `gdalraster::addFilesInZip()` if GDAL < 3.7.0. Currently showing as an error on CRAN at https://cran.r-project.org/web/checks/check_results_geotargets.html:

```
    ── Error ('test-tar-terra-rast.R:223:3'): metadata is maintained (gdalraster SOZip) ──
    <tar_condition_run/tar_condition_targets/rlang_error/rlang_error/error/condition>
    Error: Error in tar_make():
      _store_ addFilesInZip() requires GDAL >= 3.7
```

In case it's of interest, I also see a warning from this test that comes from a GDAL warning:

```
Warning (test-tar-terra-rast.R:228:3): metadata is maintained (gdalraster SOZip)
GDAL Message 1: NaN converted to INT_MAX.
```

Since that test uses an HFA file type, it may be due to: https://github.com/OSGeo/gdal/pull/12323

I'm using GDAL 3.10.3 on Ubuntu.
