### PR TITLE
Snapshot test update

### DIFF
--- a/man/tar_stars.Rd
+++ b/man/tar_stars.Rd
@@ -127,8 +127,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -167,7 +167,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_rast.Rd
+++ b/man/tar_terra_rast.Rd
@@ -100,8 +100,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -140,7 +140,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_sds.Rd
+++ b/man/tar_terra_sds.Rd
@@ -80,8 +80,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -120,7 +120,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_sprc.Rd
+++ b/man/tar_terra_sprc.Rd
@@ -80,8 +80,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -120,7 +120,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_tiles.Rd
+++ b/man/tar_terra_tiles.Rd
@@ -79,8 +79,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -119,7 +119,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_vect.Rd
+++ b/man/tar_terra_vect.Rd
@@ -80,8 +80,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -120,7 +120,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/man/tar_terra_vrt.Rd
+++ b/man/tar_terra_vrt.Rd
@@ -110,8 +110,8 @@ storage.
 Note: if \code{repository} is not \code{"local"} and \code{format} is \code{"file"}
 then the target should create a single output file.
 That output file is uploaded to the cloud and tracked for changes
-where it exists in the cloud. The local file is deleted after
-the target runs.}
+where it exists in the cloud. As of \code{targets} version 1.11.0 and higher,
+the local file is no longer deleted after the target runs.}
 
 \item{error}{Character of length 1, what to do if the target
 stops and throws an error. Options:
@@ -150,7 +150,8 @@ for non-dynamically-branched targets that other targets
 dynamically branch over. For example: if your pipeline has
 \code{tar_target(name = y, command = x, pattern = map(x))},
 then \code{tar_target(name = x, command = f(), memory = "auto")}
-will use persistent memory in order to avoid rereading all of \code{x}
+will use persistent memory for \code{x}
+in order to avoid rereading all of \code{x}
 for every branch of \code{y}.
 \item \code{"transient"}: the target gets unloaded
 after every new target completes.

--- a/tests/testthat/_snaps/tar-terra-rast.md
+++ b/tests/testthat/_snaps/tar-terra-rast.md
@@ -4,7 +4,7 @@
       x
     Output
       class       : SpatRaster 
-      dimensions  : 90, 95, 1  (nrow, ncol, nlyr)
+      size        : 90, 95, 1  (nrow, ncol, nlyr)
       resolution  : 0.008333333, 0.008333333  (x, y)
       extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
       coord. ref. : lon/lat WGS 84 (EPSG:4326) 

--- a/tests/testthat/_snaps/tar-terra-sprc.md
+++ b/tests/testthat/_snaps/tar-terra-sprc.md
@@ -18,7 +18,7 @@
       x[1]
     Output
       class       : SpatRaster 
-      dimensions  : 90, 95, 1  (nrow, ncol, nlyr)
+      size        : 90, 95, 1  (nrow, ncol, nlyr)
       resolution  : 0.008333333, 0.008333333  (x, y)
       extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
       coord. ref. : lon/lat WGS 84 (EPSG:4326) 
@@ -35,7 +35,7 @@
       x[2]
     Output
       class       : SpatRaster 
-      dimensions  : 115, 114, 1  (nrow, ncol, nlyr)
+      size        : 115, 114, 1  (nrow, ncol, nlyr)
       resolution  : 683.4048, 683.4048  (x, y)
       extent      : 1480982, 1558890, 5478149, 5556741  (xmin, xmax, ymin, ymax)
       coord. ref. : +proj=igh +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs 
@@ -67,7 +67,7 @@
       x[1]
     Output
       class       : SpatRaster 
-      dimensions  : 90, 95, 1  (nrow, ncol, nlyr)
+      size        : 90, 95, 1  (nrow, ncol, nlyr)
       resolution  : 0.008333333, 0.008333333  (x, y)
       extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
       coord. ref. : lon/lat WGS 84 (EPSG:4326) 
@@ -84,7 +84,7 @@
       x[2]
     Output
       class       : SpatRaster 
-      dimensions  : 90, 95, 1  (nrow, ncol, nlyr)
+      size        : 90, 95, 1  (nrow, ncol, nlyr)
       resolution  : 0.008333333, 0.008333333  (x, y)
       extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
       coord. ref. : lon/lat WGS 84 (EPSG:4326) 


### PR DESCRIPTION
This addresses failing pkgcheck by updating some snapshots that changed because of apparent changes in `terra` print methods.  It also updates documentation inherited from `targets`